### PR TITLE
Update Sendwithus API Version + Add Support for Laravel 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 node_modules/
 npm-debug.log
+composer.lock
 
 # Laravel 4 specific
 bootstrap/compiled.php

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.0",
-        "sendwithus/api": "^4.0.0",
+        "illuminate/support": "~6.0|~5.0",
+        "sendwithus/api": "^6.3",
         "php": "~7.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "graham-campbell/testbench": "^3.4",
-        "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "5.7.21"
+        "graham-campbell/testbench": "^5.4",
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This updates the Sendwithus API package dependency to its latest stable version. It also allows for the `illuminate/support` package to be version 6.* in order to support Laravel 6. The included dev dependency `graham-campbell/testbench` has been updated in to provide compatibility with Laravel 5.5-7, and Mockery and PHPUnit have been updated as a result.
